### PR TITLE
Elements now get addTooltip called when in Tabs.

### DIFF
--- a/src/main/java/cofh/lib/gui/element/TabBase.java
+++ b/src/main/java/cofh/lib/gui/element/TabBase.java
@@ -360,6 +360,20 @@ public abstract class TabBase extends ElementBase {
 	}
 
 	@Override
+	public void addTooltip(List<String> list) {
+		for(int i = 0; i < this.elements.size(); i++) {
+			ElementBase c = elements.get(i);
+
+			if (!c.isVisible() || !c.isEnabled() || !c.intersectsWith(mouseX, mouseY)) {
+				continue;
+			}
+
+			c.addTooltip(list);
+
+		}
+	}
+
+	@Override
 	public boolean onKeyTyped(char characterTyped, int keyPressed) {
 
 		for (int i = elements.size(); i-- > 0;) {


### PR DESCRIPTION
Hopefully self explanatory, It was a small oversight I just noticed.