### PR TITLE
Code quality fix - "final" classes should not have "protected" members.

### DIFF
--- a/src/main/java/cofh/lib/util/ArrayHashList.java
+++ b/src/main/java/cofh/lib/util/ArrayHashList.java
@@ -19,9 +19,9 @@ public class ArrayHashList<E extends Object> extends AbstractCollection<E> imple
 
 	protected static final class Entry {
 
-		protected final Object key;
-		protected final int hash;
-		protected Entry nextInBucket;
+		final Object key;
+		final int hash;
+		Entry nextInBucket;
 
 		protected Entry(Object key, int keyHash) {
 

--- a/src/main/java/cofh/lib/util/BlockWrapper.java
+++ b/src/main/java/cofh/lib/util/BlockWrapper.java
@@ -47,7 +47,7 @@ public final class BlockWrapper {
 		return false;
 	}
 
-	protected final int getId() {
+	final int getId() {
 
 		return Block.getIdFromBlock(block);
 	}

--- a/src/main/java/cofh/lib/util/LinkedHashList.java
+++ b/src/main/java/cofh/lib/util/LinkedHashList.java
@@ -18,11 +18,11 @@ public class LinkedHashList<E extends Object> extends AbstractCollection<E> impl
 
 	protected static final class Entry {
 
-		protected Entry next;
-		protected Entry prev;
-		protected final Object key;
-		protected final int hash;
-		protected Entry nextInBucket;
+		Entry next;
+		Entry prev;
+		final Object key;
+		final int hash;
+		Entry nextInBucket;
 
 		protected Entry(Object key, int keyHash) {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2156 -  "final" classes should not have "protected" members. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2156

Please let me know if you have any questions.

Faisal Hameed