### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/cofh/lib/gui/GuiProps.java
+++ b/src/main/java/cofh/lib/gui/GuiProps.java
@@ -9,5 +9,9 @@ public class GuiProps {
 	public static final String PATH_RENDER = PATH_GFX + "blocks/";
 	public static final String PATH_ELEMENTS = PATH_GUI + "elements/";
 	public static final String PATH_ICON = PATH_GUI + "icons/";
+	
+	private GuiProps() {
+		
+	}
 
 }

--- a/src/main/java/cofh/lib/gui/TabTracker.java
+++ b/src/main/java/cofh/lib/gui/TabTracker.java
@@ -12,6 +12,10 @@ public class TabTracker {
 
 	private static Class<? extends TabBase> openedLeftTab;
 	private static Class<? extends TabBase> openedRightTab;
+	
+	private TabTracker() {
+		
+	}
 
 	public static Class<? extends TabBase> getOpenedLeftTab() {
 

--- a/src/main/java/cofh/lib/inventory/InventoryManager.java
+++ b/src/main/java/cofh/lib/inventory/InventoryManager.java
@@ -5,6 +5,10 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class InventoryManager {
+	
+	private InventoryManager() {
+		
+	}
 
 	public static IInventoryManager create(Object inventory, ForgeDirection targetSide) {
 

--- a/src/main/java/cofh/lib/network/ByteBufHelper.java
+++ b/src/main/java/cofh/lib/network/ByteBufHelper.java
@@ -3,6 +3,10 @@ package cofh.lib.network;
 import io.netty.buffer.ByteBuf;
 
 public final class ByteBufHelper {
+	
+	private ByteBufHelper() {
+		
+	}
 
 	public static int readVarInt(ByteBuf data) {
 

--- a/src/main/java/cofh/lib/util/helpers/BlockHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/BlockHelper.java
@@ -79,6 +79,10 @@ public final class BlockHelper {
 		public static final int CHEST = 9;
 		public static final int LEVER = 10;
 		public static final int SIGN = 11;
+		
+		private RotationType() {
+			
+		}
 	}
 
 	static { // TODO: review which of these can be removed in favor of the vanilla handler

--- a/src/main/java/cofh/lib/util/helpers/FireworksHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/FireworksHelper.java
@@ -16,6 +16,10 @@ import net.minecraft.nbt.NBTTagList;
  */
 public final class FireworksHelper {
 
+	private FireworksHelper() {
+		
+	}
+	
 	/**
 	 * Represents a single explosion that a firework rocket can contain.
 	 *

--- a/src/main/java/cofh/lib/util/helpers/NBTHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/NBTHelper.java
@@ -11,6 +11,10 @@ import net.minecraft.nbt.NBTTagCompound;
  *
  */
 public final class NBTHelper {
+	
+	private NBTHelper() {
+		
+	}
 
 	public static NBTTagCompound getTagCompound(ItemStack stack) {
 

--- a/src/main/java/cofh/lib/util/helpers/SoundHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/SoundHelper.java
@@ -15,6 +15,10 @@ import net.minecraft.client.audio.SoundHandler;
 public class SoundHelper {
 
 	public static final SoundHandler soundManager = FMLClientHandler.instance().getClient().getSoundHandler();
+	
+	private SoundHelper() {
+		
+	}
 
 	/**
 	 * This allows you to have some tricky functionality with Tile Entities. Just be sure you aren't dumb.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed