### PR TITLE
Fix possible StackOverflow in WorldGenAdvLakes

### DIFF
--- a/src/main/java/cofh/lib/world/WorldGenAdvLakes.java
+++ b/src/main/java/cofh/lib/world/WorldGenAdvLakes.java
@@ -41,9 +41,6 @@ public class WorldGenAdvLakes extends WorldGenerator {
 	public boolean generate(World world, Random rand, int xStart, int yStart, int zStart) {
 
 		int widthOff = width / 2;
-		xStart -= widthOff;
-		zStart -= widthOff;
-
 		int heightOff = height / 2 + 1;
 
 		while (yStart > heightOff && world.isAirBlock(xStart, yStart, zStart)) {
@@ -54,7 +51,9 @@ public class WorldGenAdvLakes extends WorldGenerator {
 			return false;
 		}
 
+		xStart -= widthOff;
 		yStart -= heightOff;
+		zStart -= widthOff;
 		boolean[] spawnBlock = new boolean[width * width * height];
 
 		int W = width - 1, H = height - 1;


### PR DESCRIPTION
Really bad idea to check the world state 8 blocks away from current position.  That location could be in another chunk, which might need generating, which might call this code, which might.... oh my goodness...!

I can see this is how it is done by Mojang for their lakes but don't think it is a good idea.  I believe this is giving me a StackOverflow.

What do you think?