### PR TITLE
Fix for lit/unlit versions

### DIFF
--- a/src/main/java/cofh/lib/util/helpers/BlockHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/BlockHelper.java
@@ -570,6 +570,7 @@ public final class BlockHelper {
 			block = Blocks.redstone_lamp;
 		}
 		
+		Item item = Item.getItemFromBlock(block);
 		if (item.getHasSubtypes()) {
 			return new ItemStack(item, 1, bMeta);
 		}

--- a/src/main/java/cofh/lib/util/helpers/BlockHelper.java
+++ b/src/main/java/cofh/lib/util/helpers/BlockHelper.java
@@ -560,8 +560,16 @@ public final class BlockHelper {
 	}
 
 	public static ItemStack createStackedBlock(Block block, int bMeta) {
-
-		Item item = Item.getItemFromBlock(block);
+		if (block == Blocks.lit_redstone_ore) {
+			block = Blocks.redstone_ore;
+		}
+		else if (block == Blocks.unlit_redstone_torch) {
+			block = Blocks.redstone_torch;
+		}
+		else if (block == Blocks.lit_redstone_lamp) {
+			block = Blocks.redstone_lamp;
+		}
+		
 		if (item.getHasSubtypes()) {
 			return new ItemStack(item, 1, bMeta);
 		}


### PR DESCRIPTION
`Item.getItemForBlock` returns null for alternate versions of certain vanilla blocks. Lit redstone ore (ID 74), unlit redstone torch (ID 75), and lit redstone lamp (ID 124) blocks do not have corresponding items. Pumpkins and furnaces also have lit/unlit versions, but both have items, so they do not have this issue.

This issue can cause null pointer exceptions when `breakBlock` is called on one of the listed blocks.

Fixes CoFH/Feedback#1289